### PR TITLE
Fixes #185

### DIFF
--- a/manager/forms.py
+++ b/manager/forms.py
@@ -50,6 +50,30 @@ class EventUserAutocomplete(autocomplete.AutocompleteModelBase):
 
         return self.order_choices(choices)[0:self.limit_choices]
 
+class EventUserInstallAutocomplete(autocomplete.AutocompleteModelBase):
+    autocomplete_js_attributes = {'placeholder': _('Search Attendee')}
+
+    def choices_for_request(self):
+        q = self.request.GET.get('q', '')
+        event_slug = self.request.GET.get('event_slug', None)
+
+        choices = []
+        if event_slug:
+            choices = self.choices.all()
+            choices = choices.filter(event__slug__iexact=event_slug).filter(assisted=True)
+            if q:
+                choices = choices.filter(
+                    Q(user__first_name__icontains=q)
+                    | Q(user__last_name__icontains=q)
+                    | Q(user__username__icontains=q)
+                    | Q(user__email__icontains=q)
+                    | Q(nonregisteredattendee__first_name__icontains=q)
+                    | Q(nonregisteredattendee__last_name__icontains=q)
+                    | Q(nonregisteredattendee__email__icontains=q)
+                )
+
+        return self.order_choices(choices)[0:self.limit_choices]
+
 
 class RegisteredEventUserAutocomplete(autocomplete.AutocompleteModelBase):
     autocomplete_js_attributes = {'placeholder': _('Type to search'),
@@ -73,6 +97,7 @@ class RegisteredEventUserAutocomplete(autocomplete.AutocompleteModelBase):
 
 
 autocomplete.register(EventUser, EventUserAutocomplete)
+autocomplete.register(EventUser, EventUserInstallAutocomplete)
 autocomplete.register(EventUser, RegisteredEventUserAutocomplete)
 autocomplete.register(Software, SoftwareAutocomplete)
 
@@ -112,7 +137,7 @@ class InstallationForm(autocomplete.ModelForm):
         super(InstallationForm, self).__init__(*args, **kwargs)
         self.fields['attendee'].queryset = EventUser.objects.filter(event__slug__iexact=event)
 
-    attendee = autocomplete.ModelChoiceField('EventUserAutocomplete', required=True)
+    attendee = autocomplete.ModelChoiceField('EventUserInstallAutocomplete', required=True)
 
     class Meta(object):
         model = Installation
@@ -205,7 +230,7 @@ class ContactForm(ModelForm):
         cleaned_data = super(ContactForm, self).clean()
         type = cleaned_data.get("type")
         value = cleaned_data.get("url")
-        
+
         if type:
             if type.validate == '1':
                 try:

--- a/manager/initial_data/software.json
+++ b/manager/initial_data/software.json
@@ -1,65 +1,90 @@
-[
-  {
-    "model": "manager.software",
-    "fields": {
-      "type": "OS",
-      "name": "Debian x86"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Debian x64"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Ubuntu x86"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Ubuntu x64"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Mint x86"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Mint x64"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Fedora x86"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Fedora x64"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Huayra x86"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Huayra x64"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Manjaro x64"
-    },
-    "fields": {
-      "type": "OS",
-      "name": "Manjaro x86"
-    },
-    "fields": {
-      "type": "OT",
-      "name": "Other"
-    },
-    "fields": {
-      "type": "SU",
-      "name": "Support"
-    },
-    "fields": {
-      "type": "AP",
-      "name": "Application"
-    }
-  }
-]
+[{
+  "fields": {
+    "type": "OS",
+    "name": "Debian x86"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OS",
+    "name": "Debian x64"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OS",
+    "name": "Ubuntu x86"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OS",
+    "name": "Ubuntu x64"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OS",
+    "name": "Mint x86"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OS",
+    "name": "Mint x64"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OS",
+    "name": "Fedora x86"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OS",
+    "name": "Fedora x64"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OS",
+    "name": "Huayra x86"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OS",
+    "name": "Huayra x64"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "AP",
+    "name": "Application"
+  },
+  "model": "manager.software"
+
+}, {
+  "fields": {
+    "type": "OT",
+    "name": "Other"
+  },
+  "model": "manager.software"
+}, {
+  "fields": {
+    "type": "SU",
+    "name": "Support"
+  },
+  "model": "manager.software"
+}]


### PR DESCRIPTION
Borrar lo que hay actualmente en la tabla Software y relodear la data.

En la vista de registrar asistentes, el autocomplete solo busca en los que todavia no fueron marcados como que asistieron
En la vista de cargar una instalacion, el autocomplete de attendee solo busca entre los que ya marcaron que asistieron. 

Si no les parece que vallan esos filtros, los mismos estan en EventUserAutocomplete y EventUserInstallAutocomplete